### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -397,7 +397,12 @@ app.get("/files/:filename", downloadLimit, async (request, response) => {
         // Note: the file path below is internal to the docker container.  
         //  Unless changed, in your docker-compose the local filesystem 
         //  should direct to the folder ../apiFolder should contain the files for this route
-        var filePath = path.join(FILE_DIRECTORY, request.params.filename);    
+        var filePath = path.resolve(FILE_DIRECTORY, request.params.filename);    
+        
+        if (!filePath.startsWith(FILE_DIRECTORY)) {
+            response.status(403).send('Forbidden');
+            return;
+        }
         
         let range = request.headers.range;
         console.log("Received a request for file: " + filePath  + ", in range: " + range);


### PR DESCRIPTION
Fixes [https://github.com/neatMon-Inc/neatmon.api/security/code-scanning/4](https://github.com/neatMon-Inc/neatmon.api/security/code-scanning/4)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. This approach will prevent path traversal attacks by ensuring that the file path does not escape the intended directory.

1. Normalize the file path using `path.resolve` to remove any ".." segments.
2. Check that the normalized path starts with the `FILE_DIRECTORY`.
3. If the path is not valid, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
