### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -397,7 +397,11 @@ app.get("/files/:filename", downloadLimit, async (request, response) => {
         // Note: the file path below is internal to the docker container.  
         //  Unless changed, in your docker-compose the local filesystem 
         //  should direct to the folder ../apiFolder should contain the files for this route
-        var filePath = path.join(FILE_DIRECTORY, request.params.filename);    
+        var filePath = path.resolve(FILE_DIRECTORY, request.params.filename);
+        if (!filePath.startsWith(FILE_DIRECTORY)) {
+            response.status(403).send('Access denied');
+            return;
+        }
         
         let range = request.headers.range;
         console.log("Received a request for file: " + filePath  + ", in range: " + range);


### PR DESCRIPTION
Fixes [https://github.com/neatMon-Inc/neatmon.api/security/code-scanning/3](https://github.com/neatMon-Inc/neatmon.api/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `path.resolve` to remove any ".." segments and then checking that the normalized path starts with the root folder. This will prevent path traversal attacks and ensure that only files within the intended directory are accessed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
