### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -397,8 +397,13 @@ app.get("/files/:filename", downloadLimit, async (request, response) => {
         // Note: the file path below is internal to the docker container.  
         //  Unless changed, in your docker-compose the local filesystem 
         //  should direct to the folder ../apiFolder should contain the files for this route
-        var filePath = path.join(FILE_DIRECTORY, request.params.filename);    
+        var filePath = path.resolve(FILE_DIRECTORY, request.params.filename);    
         
+        if (!filePath.startsWith(FILE_DIRECTORY)) {
+            response.status(403).send('Forbidden');
+            return;
+        }
+
         let range = request.headers.range;
         console.log("Received a request for file: " + filePath  + ", in range: " + range);
 


### PR DESCRIPTION
Fixes [https://github.com/neatMon-Inc/neatmon.api/security/code-scanning/2](https://github.com/neatMon-Inc/neatmon.api/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `path.resolve` to remove any `..` segments and then checking that the normalized path starts with the root folder. This approach ensures that even if a malicious filename is provided, it cannot escape the intended directory.

1. Normalize the file path using `path.resolve`.
2. Check that the normalized path starts with the `FILE_DIRECTORY`.
3. If the path is not valid, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
